### PR TITLE
🧹 Remove redundant legacy embedding storage function

### DIFF
--- a/adaptive_memory_v4.0.py
+++ b/adaptive_memory_v4.0.py
@@ -909,20 +909,6 @@ class EmbeddingManager:
             json.dump(cache, f)
         os.replace(tmp_file, cache_file)
 
-    def _store_embedding_legacy_json_sync(
-        self, user_id: str, memory_id: str, embedding: np.ndarray
-    ) -> None:
-        memory_id_str = normalize_memory_id(memory_id)
-        cache = self._load_legacy_cache_sync(user_id)
-        model, provider = self._default_record_identity()
-        cache[memory_id_str] = {
-            "embedding": np.asarray(embedding, dtype=np.float32).tolist(),
-            "model": model,
-            "provider": provider,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
-        self._save_legacy_cache_sync(user_id, cache)
-
     def _store_embeddings_batch_legacy_json_sync(
         self, user_id: str, ids: List[str], embeddings: List[np.ndarray]
     ) -> None:
@@ -1164,7 +1150,10 @@ class EmbeddingManager:
                 )
                 try:
                     await asyncio.to_thread(
-                        self._store_embedding_legacy_json_sync, user_id, memory_id, embedding
+                        self._store_embeddings_batch_legacy_json_sync,
+                        user_id,
+                        [memory_id],
+                        [embedding],
                     )
                 except Exception as legacy_err:
                     logger.warning(


### PR DESCRIPTION
The redundant `_store_embedding_legacy_json_sync` function was removed from the `EmbeddingManager` class in `adaptive_memory_v4.0.py`. Its sole fallback call in the `store_embedding_persistent` method was refactored to utilize the more versatile `_store_embeddings_batch_legacy_json_sync` method, passing single-item lists for the ID and embedding. This refactoring eliminates dead code and reduces duplication without altering functionality, as both methods shared the same underlying logic for JSON persistence. The change was verified through manual inspection, syntax checks, and confirming the removal of all references to the old method.

---
*PR created automatically by Jules for task [17532089989082395822](https://jules.google.com/task/17532089989082395822) started by @1818TusculumSt*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of legacy data persistence logic with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->