### PR TITLE
🧹 [code health] remove unused TaskManager placeholder comment

### DIFF
--- a/adaptive_memory_v4.0.py
+++ b/adaptive_memory_v4.0.py
@@ -2327,7 +2327,6 @@ Your output must be valid JSON only. No additional text.""",
 
         return body
 
-    # ... Placeholder for other required methods (referenced by TaskManager) ...
     async def _summarize_old_memories_loop(self):
         """Background task for summarization."""
         logger.info(f"Summarization background task launched with interval: {self.valves.summarization_interval} seconds")


### PR DESCRIPTION
The goal was to remove an unused placeholder comment in `adaptive_memory_v4.0.py`. I identified the comment at line 2330 and removed it. I verified the change by running a syntax check and a functional verification script (which was later removed to keep the PR clean).

🎯 **What:** Removed an unused TaskManager placeholder comment.
💡 **Why:** To improve code maintainability and readability by removing obsolete comments.
✅ **Verification:** Verified via `python3 -m py_compile` and a manual instantiation test.
✨ **Result:** A cleaner codebase with less redundant commentary.

---
*PR created automatically by Jules for task [14866490896697645574](https://jules.google.com/task/14866490896697645574) started by @1818TusculumSt*