### PR TITLE
Small changes to use current conversation model by default unless a model is specified in the valve.

### DIFF
--- a/adaptive_memory_v4.0.py
+++ b/adaptive_memory_v4.0.py
@@ -6393,8 +6393,8 @@ Analyze the following related memories and provide a concise summary.""",
             description="Type of LLM provider ('ollama' or 'openai_compatible')",
         )
         llm_model_name: str = Field(
-            default="llama3:latest",
-            description="Name of the LLM model to use (e.g., 'llama3:latest', 'gpt-4o')",
+            default="",
+            description="Name of the LLM model to use (e.g., 'llama3:latest', 'gpt-4o'). Leave blank to use the current conversation model.",
         )
         llm_api_endpoint_url: str = Field(
             default="http://host.docker.internal:11434/api/chat",
@@ -7171,10 +7171,11 @@ Your output must be valid JSON only. No additional text.""",
     # --------------------------------------------------------------------------
     # Helper: LLM Query Wrapper
     # --------------------------------------------------------------------------
-    async def _query_llm(self, system_prompt: str, user_prompt: str) -> Optional[str]:
+    async def _query_llm(self, system_prompt: str, user_prompt: str, model_override: Optional[str] = None) -> Optional[str]:
         """Unified LLM query method with retries and metrics."""
         valves = self.valves
-        
+        model_name = model_override or valves.llm_model_name  # use override if provided
+
         for attempt in range(valves.max_retries + 1):
             start = time.perf_counter()
             try:
@@ -7194,7 +7195,7 @@ Your output must be valid JSON only. No additional text.""",
                         headers["Authorization"] = f"Bearer {secret_value(valves.llm_api_key)}"
 
                     payload = {
-                        "model": valves.llm_model_name,
+                        "model": model_name,
                         "messages": [
                             {"role": "system", "content": system_prompt},
                             {"role": "user", "content": user_prompt},
@@ -7465,7 +7466,12 @@ Your output must be valid JSON only. No additional text.""",
                     retrieval_query, user_id, all_memories
                 )
 
-            # Pass our _query_llm as callback
+            # Pass our _query_llm as callback, bound to the current conversation model
+            current_model = body.get("model")
+
+            async def _bound_query_llm(system_prompt, user_prompt):
+                return await self._query_llm(system_prompt, user_prompt, fallback_model=current_model)
+
             ops = await pipeline.identify_memories(
                 user_message,
                 context_memories=context_memories,

--- a/adaptive_memory_v4.0.py
+++ b/adaptive_memory_v4.0.py
@@ -7171,10 +7171,23 @@ Your output must be valid JSON only. No additional text.""",
     # --------------------------------------------------------------------------
     # Helper: LLM Query Wrapper
     # --------------------------------------------------------------------------
-    async def _query_llm(self, system_prompt: str, user_prompt: str, model_override: Optional[str] = None) -> Optional[str]:
+    async def _query_llm(self, system_prompt: str, user_prompt: str, model_override: Optional[str] = None,) -> Optional[str]:
         """Unified LLM query method with retries and metrics."""
         valves = self.valves
-        model_name = model_override or valves.llm_model_name  # use override if provided
+        # model_name = model_override or valves.llm_model_name  # use override if provided
+
+        model_name = str(model_override or valves.llm_model_name or "").strip()
+        if not model_name:
+            logger.warning(
+                "llm_request_failed %s",
+                safe_log_context(
+                    provider=valves.llm_provider_type,
+                    operation="LLM_QUERY",
+                    reason="missing_model",
+                ),
+            )
+            self.error_manager.increment("llm_call_errors")
+            return None
 
         for attempt in range(valves.max_retries + 1):
             start = time.perf_counter()
@@ -7467,15 +7480,16 @@ Your output must be valid JSON only. No additional text.""",
                 )
 
             # Pass our _query_llm as callback, bound to the current conversation model
-            current_model = body.get("model")
-
+            #current_model = body.get("model")
+            current_model = str(body.get("model") or "").strip() or None
+            
             async def _bound_query_llm(system_prompt, user_prompt):
-                return await self._query_llm(system_prompt, user_prompt, fallback_model=current_model)
+                return await self._query_llm(system_prompt, user_prompt, model_override=current_model)
 
             ops = await pipeline.identify_memories(
                 user_message,
                 context_memories=context_memories,
-                query_llm_func=self._query_llm,
+                query_llm_func=_bound_query_llm,
                 user_id=user_id,
                 session_id=session_id,
             )


### PR DESCRIPTION
I am not sure if this is the direction you want to go, but I wanted to be able to use many different models without constantly changing the valve. This was the easiest method that I could get to work. Figured I would share in case you wanted to implement the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model selection now respects conversation-specific model choices, allowing per-conversation overrides instead of always using the global default.
  * Default model configuration cleared to encourage explicit selection and reduce unintended model usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->