### PR TITLE
🔒 [security fix] Prevent SQL injection in ALTER TABLE and PRAGMA identifiers

### DIFF
--- a/adaptive_memory_v4.0.py
+++ b/adaptive_memory_v4.0.py
@@ -1873,6 +1873,11 @@ class Mem0SyncManager:
     def _timeout(self) -> aiohttp.ClientTimeout:
         return aiohttp.ClientTimeout(total=float(self.get_valves().mem0_timeout_seconds))
 
+    def _quote_identifier(self, identifier: str) -> str:
+        """Safely quote a SQL identifier by doubling double-quotes and wrapping in quotes."""
+        safe_id = identifier.replace('"', '""')
+        return f'"{safe_id}"'
+
     def _connect_db(self) -> sqlite3.Connection:
         os.makedirs(self._cache_root, exist_ok=True)
         conn = sqlite3.connect(
@@ -1947,12 +1952,16 @@ class Mem0SyncManager:
     def _ensure_db_column(
         self, conn: sqlite3.Connection, table_name: str, column_name: str, ddl: str
     ) -> None:
+        quoted_table = self._quote_identifier(table_name)
+        quoted_column = self._quote_identifier(column_name)
         columns = {
             str(row["name"])
-            for row in conn.execute(f"PRAGMA table_info({table_name})").fetchall()
+            for row in conn.execute(f"PRAGMA table_info({quoted_table})").fetchall()
         }
         if column_name not in columns:
-            conn.execute(f"ALTER TABLE {table_name} ADD COLUMN {column_name} {ddl}")
+            conn.execute(
+                f"ALTER TABLE {quoted_table} ADD COLUMN {quoted_column} {ddl}"
+            )
 
     def _upsert_mapping_sync(
         self, user_id: str, owui_memory_id: str, mem0_memory_id: str


### PR DESCRIPTION
🎯 **What:** This PR fixes a SQL injection vulnerability in `adaptive_memory_v4.0.py`.

⚠️ **Risk:** The `_ensure_db_column` method was directly interpolating `table_name` and `column_name` into SQL strings for `PRAGMA table_info` and `ALTER TABLE`. Since SQLite doesn't support parameterized queries for DDL identifiers, this allowed potential SQL injection if these identifiers were sourced from untrusted input.

🛡️ **Solution:** Implemented a `_quote_identifier` helper method in the `Mem0SyncManager` class that safely quotes SQL identifiers by wrapping them in double quotes and doubling any internal double quotes, following standard SQLite conventions. Updated `_ensure_db_column` to use this helper for all identifier interpolations.

Verified the fix with a reproduction script and confirmed no regressions by running the existing test suite.

---
*PR created automatically by Jules for task [14098602303205381398](https://jules.google.com/task/14098602303205381398) started by @1818TusculumSt*