### PR TITLE
🔒 [security] Fix SQL Injection in PRAGMA table_info and ALTER TABLE

### DIFF
--- a/adaptive_memory_v4.0.py
+++ b/adaptive_memory_v4.0.py
@@ -1952,13 +1952,33 @@ class Mem0SyncManager:
     def _ensure_db_column(
         self, conn: sqlite3.Connection, table_name: str, column_name: str, ddl: str
     ) -> None:
-        quoted_table = self._quote_identifier(table_name)
-        quoted_column = self._quote_identifier(column_name)
+        """Ensure a column exists in a table, adding it if necessary.
+        Uses pragma_table_info(?) for safe parameterized inspection of table schema.
+        Note: ALTER TABLE identifiers cannot be parameterized, so they are quoted.
+        """
+        # Validate identifiers to contain only alphanumeric or underscores
+        # as an extra layer of defense for ALTER TABLE
+        import re
+
+        if not re.match(r"^[a-zA-Z0-9_]+$", table_name):
+            raise ValueError(f"Invalid table name: {table_name}")
+        if not re.match(r"^[a-zA-Z0-9_]+$", column_name):
+            raise ValueError(f"Invalid column name: {column_name}")
+
         columns = {
             str(row["name"])
-            for row in conn.execute(f"PRAGMA table_info({quoted_table})").fetchall()
+            for row in conn.execute(
+                "SELECT name FROM pragma_table_info(?)", (table_name,)
+            ).fetchall()
         }
         if column_name not in columns:
+            quoted_table = self._quote_identifier(table_name)
+            quoted_column = self._quote_identifier(column_name)
+            # ddl is also potentially risky, but here it is controlled by the caller
+            # and usually just 'TEXT' or similar. Still, we can do a basic check.
+            if ";" in ddl:
+                raise ValueError(f"Invalid DDL: {ddl}")
+
             conn.execute(
                 f"ALTER TABLE {quoted_table} ADD COLUMN {quoted_column} {ddl}"
             )


### PR DESCRIPTION
This PR addresses a potential SQL injection vulnerability in the `_ensure_db_column` method of `adaptive_memory_v4.0.py`.

### 🎯 What:
The vulnerability existed where SQL identifiers (table and column names) were being interpolated into a `PRAGMA table_info` call using f-strings.

### ⚠️ Risk:
An attacker who could control table or column names might have been able to execute arbitrary SQL commands, potentially leading to data loss or unauthorized access. Although the current code had some quoting, using parameterized queries is the industry standard for preventing such issues.

### 🛡️ Solution:
1.  **Parameterized Inspection:** Replaced `PRAGMA table_info({quoted_table})` with `SELECT name FROM pragma_table_info(?)`, which supports parameters and is more secure.
2.  **Input Validation:** Added strict regex validation (`^[a-zA-Z0-9_]+$`) for `table_name` and `column_name`. Since `ALTER TABLE` does not support parameterized identifiers, this validation ensures that only safe characters are used.
3.  **DDL Guard:** Added a check to prevent semicolons in the `ddl` argument, preventing statement chaining.

Verified with a reproduction script and confirmed that all existing tests pass.

---
*PR created automatically by Jules for task [18188146876455216965](https://jules.google.com/task/18188146876455216965) started by @1818TusculumSt*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced database safety with parameterized queries and validation checks to prevent potential SQL injection vulnerabilities in table column operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1818TusculumSt/owui-adaptive-memory/pull/41?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->